### PR TITLE
Preset: Tokyo Night + macOS ~/.config support

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,6 +113,8 @@ style = "bold yellow"
     - _**[See docs/presets/pure_prompt.md.](docs/presets/pure_prompt.md)**_
 - Pastel Powerline
     - _**[See docs/presets/pastel_powerline.md](docs/presets/pastel_powerline.md)**_
+- Tokyo Night (foreground-only)
+    - _**[See docs/presets/tokyo_night.md](docs/presets/tokyo_night.md)**_
 
 ## Acknowledgments
 

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ style = "bold yellow"
     - _**[See docs/presets/pure_prompt.md.](docs/presets/pure_prompt.md)**_
 - Pastel Powerline
     - _**[See docs/presets/pastel_powerline.md](docs/presets/pastel_powerline.md)**_
-- Tokyo Night (foreground-only)
+- Tokyo Night
     - _**[See docs/presets/tokyo_night.md](docs/presets/tokyo_night.md)**_
 
 ## Acknowledgments

--- a/docs/presets/pastel_powerline.md
+++ b/docs/presets/pastel_powerline.md
@@ -14,7 +14,8 @@ format = """
 [ ](bg:#9A348E)\
 $directory\
 [ ](bg:#DA627D fg:#9A348E)\
-$git_branch$git_status\
+$git_branch
+$git_status\
 [ ](fg:#DA627D bg:#FCA17D)\
 $claude_model\
 [ ](fg:#FCA17D)\

--- a/docs/presets/pastel_powerline.md
+++ b/docs/presets/pastel_powerline.md
@@ -14,8 +14,7 @@ format = """
 [ ](bg:#9A348E)\
 $directory\
 [ ](bg:#DA627D fg:#9A348E)\
-$git_branch
-$git_status\
+$git_branch$git_status\
 [ ](fg:#DA627D bg:#FCA17D)\
 $claude_model\
 [ ](fg:#FCA17D)\

--- a/docs/presets/tokyo_night.md
+++ b/docs/presets/tokyo_night.md
@@ -12,13 +12,13 @@ This preset approximates Starship’s “Tokyo Night” with cool, dark-friendly
 ```toml
 format = """
 [░▒▓](#a3aed2)\
-[ ](bg:#769ff0 fg:#a3aed2)\
+[ ](bg:#769ff0 fg:#a3aed2)\
 $directory\
-[ ](fg:#769ff0 bg:#394260)\
+[ ](fg:#769ff0 bg:#394260)\
 $git_branch$git_status\
-[ ](fg:#394260 bg:#212736)\
+[ ](fg:#394260 bg:#212736)\
 $claude_model\
-[ ](fg:#212736)\
+[ ](fg:#212736)\
 """
 
 [directory]

--- a/docs/presets/tokyo_night.md
+++ b/docs/presets/tokyo_night.md
@@ -1,47 +1,49 @@
 # Preset: Tokyo Night
 
-This preset approximates Starship’s “Tokyo Night” using foreground-only colors and simple character separators. It targets dark terminals with cool-toned accents and avoids backgrounds/truecolor for maximum portability.
+This preset approximates Starship’s “Tokyo Night” with cool, dark-friendly tones. The core supports both foreground and background colors, including 24-bit hex.
 
 ## Key decisions
-- Foreground-only styling: no backgrounds, no truecolor required.
-- Subtle separators using `` in gray;
-- Cool tones (cyan/blue/magenta) for a Tokyo Night feel on dark themes.
+- Use truecolor backgrounds with Powerline-style bridges for a cohesive look.
+- Bridge arrows `` specify `fg:<prev-bg> bg:<next-bg>` for seamless transitions.
+- Provide a simple `|` fallback when Powerline glyphs are unavailable.
 
 ## Configuration (~/.config/claude-code-statusline.toml)
 
 ```toml
-# Characters-only, foreground-only approximation
+# Background + truecolor variant
 format = """
-[░▒▓](#a3aed2)\
-[ ](bg:#769ff0 fg:#a3aed2)\
+[ ](bg:#1f2335)\
 $directory\
-[ ](fg:#769ff0 bg:#394260)\
-$git_branch\
-$git_status\
-[ ](fg:#394260 bg:#212736)\
+[ ](bg:#2a2f4a fg:#1f2335)\
+$git_branch$git_status\
+[ ](bg:#3b4261 fg:#2a2f4a)\
 $claude_model\
-[ ](fg:#212736)\
+[ ](fg:#3b4261)\
+"""
 
 [directory]
-style = "fg:#e3e5e5 bg:#769ff0"
+style = "fg:#c0caf5 bg:#1f2335"
 format = "[ $path ]($style)"
 truncation_length = 3
 truncation_symbol = "…/"
 
 [git_branch]
 symbol = ""
-style = "bg:#394260"
+style = "fg:#7aa2f7 bg:#2a2f4a"
+format = "[$symbol $branch]($style)"
 
 [git_status]
-style = "bg:#394260"
+style = "fg:#9ece6a bg:#2a2f4a"
+format = "[$all_status$ahead_behind ]($style)"
 
 [claude_model]
-style = "bg:#212736"
+style = "fg:#c0caf5 bg:#3b4261"
+format = "[$model]($style)"
 ```
 
 ## Notes
-- This preset intentionally avoids backgrounds to remain readable and consistent across terminals that don’t support truecolor or custom palettes.
 - Outside a Git repository, `git_branch` and `git_status` hide automatically.
+- If your terminal doesn’t support 24‑bit color, replace hex with nearest 8‑bit indexes or switch to a foreground‑only style.
 
 ## References
 - Starship Preset (Tokyo Night): https://starship.rs/presets/tokyo-night

--- a/docs/presets/tokyo_night.md
+++ b/docs/presets/tokyo_night.md
@@ -1,0 +1,47 @@
+# Preset: Tokyo Night (foreground-only)
+
+This preset approximates Starship’s “Tokyo Night” using foreground-only colors and simple character separators. It targets dark terminals with cool-toned accents and avoids backgrounds/truecolor for maximum portability.
+
+## Key decisions
+- Foreground-only styling: no backgrounds, no truecolor required.
+- Subtle separators using `` in gray;
+- Cool tones (cyan/blue/magenta) for a Tokyo Night feel on dark themes.
+
+## Configuration (~/.config/claude-code-statusline.toml)
+
+```toml
+# Characters-only, foreground-only approximation
+format = """
+[░▒▓](#a3aed2)\
+[ ](bg:#769ff0 fg:#a3aed2)\
+$directory\
+[ ](fg:#769ff0 bg:#394260)\
+$git_branch\
+$git_status\
+[ ](fg:#394260 bg:#212736)\
+$claude_model\
+[ ](fg:#212736)\
+
+[directory]
+style = "fg:#e3e5e5 bg:#769ff0"
+format = "[ $path ]($style)"
+truncation_length = 3
+truncation_symbol = "…/"
+
+[git_branch]
+symbol = ""
+style = "bg:#394260"
+
+[git_status]
+style = "bg:#394260"
+
+[claude_model]
+style = "bg:#212736"
+```
+
+## Notes
+- This preset intentionally avoids backgrounds to remain readable and consistent across terminals that don’t support truecolor or custom palettes.
+- Outside a Git repository, `git_branch` and `git_status` hide automatically.
+
+## References
+- Starship Preset (Tokyo Night): https://starship.rs/presets/tokyo-night

--- a/docs/presets/tokyo_night.md
+++ b/docs/presets/tokyo_night.md
@@ -10,34 +10,34 @@ This preset approximates Starship’s “Tokyo Night” with cool, dark-friendly
 ## Configuration (~/.config/claude-code-statusline.toml)
 
 ```toml
-# Background + truecolor variant
 format = """
-[ ](bg:#1f2335)\
+[░▒▓](#a3aed2)\
+[ ](bg:#769ff0 fg:#a3aed2)\
 $directory\
-[ ](bg:#2a2f4a fg:#1f2335)\
+[ ](fg:#769ff0 bg:#394260)\
 $git_branch$git_status\
-[ ](bg:#3b4261 fg:#2a2f4a)\
+[ ](fg:#394260 bg:#212736)\
 $claude_model\
-[ ](fg:#3b4261)\
+[ ](fg:#212736)\
 """
 
 [directory]
-style = "fg:#c0caf5 bg:#1f2335"
+style = "fg:#e3e5e5 bg:#769ff0"
 format = "[ $path ]($style)"
 truncation_length = 3
 truncation_symbol = "…/"
 
 [git_branch]
+style = "bg:#394260"
 symbol = ""
-style = "fg:#7aa2f7 bg:#2a2f4a"
 format = "[$symbol $branch]($style)"
 
 [git_status]
-style = "fg:#9ece6a bg:#2a2f4a"
+style = "bg:#394260"
 format = "[$all_status$ahead_behind ]($style)"
 
 [claude_model]
-style = "fg:#c0caf5 bg:#3b4261"
+style = "bg:#212736"
 format = "[$model]($style)"
 ```
 

--- a/docs/presets/tokyo_night.md
+++ b/docs/presets/tokyo_night.md
@@ -1,4 +1,4 @@
-# Preset: Tokyo Night (foreground-only)
+# Preset: Tokyo Night
 
 This preset approximates Starship’s “Tokyo Night” using foreground-only colors and simple character separators. It targets dark terminals with cool-toned accents and avoids backgrounds/truecolor for maximum portability.
 


### PR DESCRIPTION
Title: Preset: Tokyo Night (foreground + background variants)

Overview
- Add Tokyo Night preset docs using supported modules (directory, git_branch, git_status, claude_model)
- Clarify background support and provide truecolor variant with Powerline bridges (), plus pipe fallback

Config Path Change (macOS)
- Prefer ~/.config/claude-code-statusline.toml when present; keep dirs::config_dir() fallback for backward compatibility
- CLI `config --path` remains platform-config-dir-based to keep display stable

Changes
- docs/presets/tokyo_night.md: add presets and examples
- README.md: update Presets link label
- crates/claude-code-statusline-core/src/config.rs: Config::load consults ~/.config first
- docs/presets/pastel_powerline.md: minor join `$git_branch$git_status`

Motivation
- Addresses #21: Preset: Tokyo Night (foreground-only approximation)
  - Provide foreground-first and background variant aligned with Starship look

Testing
- cargo test --workspace: all tests pass
- pre-commit checks (fmt, clippy) pass

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* New Features
  * Configuration now loads from standard locations, including XDG (~/.config/claude-code-statusline.toml), with sensible fallbacks.
  * Clearer error messages when configuration files can’t be read or parsed.

* Documentation
  * Added a Tokyo Night preset guide with configuration examples and usage notes.
  * Linked the new preset in the Preset Styles section of the README.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->