### PR TITLE
Support truncate_to_repo and truncation_symbol (#37)

### DIFF
--- a/crates/claude-code-statusline-core/src/types/config.rs
+++ b/crates/claude-code-statusline-core/src/types/config.rs
@@ -78,6 +78,10 @@ pub struct DirectoryConfig {
     #[serde(default = "default_directory_truncate_to_repo")]
     pub truncate_to_repo: bool,
 
+    /// Symbol to indicate truncated paths (e.g., "…/")
+    #[serde(default = "default_directory_truncation_symbol")]
+    pub truncation_symbol: String,
+
     #[serde(default = "default_disabled")]
     pub disabled: bool,
 }
@@ -122,6 +126,7 @@ impl Default for DirectoryConfig {
             style: default_directory_style(),
             truncation_length: default_directory_truncation_length(),
             truncate_to_repo: default_directory_truncate_to_repo(),
+            truncation_symbol: default_directory_truncation_symbol(),
             disabled: default_disabled(),
         }
     }
@@ -266,6 +271,10 @@ fn default_directory_truncation_length() -> usize {
 
 fn default_directory_truncate_to_repo() -> bool {
     true
+}
+
+fn default_directory_truncation_symbol() -> String {
+    "".to_string()
 }
 
 // Claude Model module defaults

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -27,6 +27,7 @@ format = "[$path]($style)"
 style = "bold cyan"
 truncation_length = 3
 truncate_to_repo = true
+truncation_symbol = ""
 disabled = false
 ```
 
@@ -38,6 +39,7 @@ Tokens: `$path`
  - `truncate_to_repo = true` のとき、ディレクトリが Git リポジトリ配下であれば、`$path` を「`<repo-name>/<relative>`」形式（リポジトリ名 + リポジトリ内相対パス）で表示します。
    - 検出順序: `feature = "git"` 有効時は `git2` の `workdir()` を優先。見つからない場合や `git` 無効時は、カレントから親に向かって `.git` ディレクトリを探索して推定します。
    - `truncation_length` は表示セグメント数の上限です。常に先頭のリポジトリ名を保持し、残りは末尾のディレクトリから詰めて表示します（例: `truncation_length = 2` → `repo/last`）。
+   - `truncation_symbol` はパスが短縮された場合の省略記号を表します。短縮が発生したとき、保持された先頭（例: リポジトリ名）と末尾の間に挿入されます（例: `repo/…/tail`）。既定値は空文字です。
    - リポジトリ外ではこのオプションは無視され、ホーム短縮のみの通常表示になります。
 
 例:


### PR DESCRIPTION
Support truncate_to_repo and truncation_symbol in directory module

This PR implements the remaining pieces requested in #37 to align our `directory` module with Starship’s behavior.

Summary
- Add `truncation_symbol` to `[directory]` config (default: empty string)
- When `truncate_to_repo = true` and truncation occurs, insert the symbol between the repo name and the kept tail segments, e.g. `repo/…/tail`
- Keep repo name always; when `truncation_length = 1`, show only the repo name (no symbol)
- Outside a repo, keep legacy behavior (home abbreviation only)
- Update docs and add tests

Defaults (Starship parity)
- `truncate_to_repo = true`
- `truncation_length = 3`
- `truncation_symbol = ""`

Testing
- Added tests to ensure:
  - Symbol appears only when truncation happens (e.g., `repo/…/d` for `truncation_length = 2`)
  - No symbol when the path fits exactly under the limit

Closes #37


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a configurable truncation_symbol for the directory display, inserted between the repository name and the truncated tail (e.g., “…/”). Defaults to no symbol; existing appearance remains unchanged unless configured.
- Refactor
  - Streamlined path truncation rendering for repository directories to improve consistency without changing defaults.
- Documentation
  - Updated configuration guide with the new truncation_symbol option and example usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->